### PR TITLE
Add favicon links and web manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>High Street Smoke Shop — Waterford, PA | Fine Cigars & Events</title>
   <meta name="description" content="High Street Smoke Shop in Waterford, PA. Fine cigars, vapes & friendly guidance. On-site cigar service for golf outings and private events." />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="shortcut icon" href="/favicon.ico" />
   <style>
     :root{
       --bg:#0f0f0f; --text:#f5f1e8; --muted:#b5b0a3; --accent:#c4a164; --golf:#1f513f;

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "High Street Smoke Shop",
+  "short_name": "High Street",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#0f0f0f",
+  "background_color": "#0f0f0f",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary
- link apple-touch-icon and multiple favicons in the HTML head
- add web manifest listing Android icons for PWA support

## Testing
- `npm test` (fails: ENOENT Could not read package.json)
- `python -m json.tool site.webmanifest`


------
https://chatgpt.com/codex/tasks/task_e_68b330a351a88331b455b86a38e4ad61