### PR TITLE
Fix icon paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>High Street Smoke Shop — Waterford, PA | Fine Cigars & Events</title>
   <meta name="description" content="High Street Smoke Shop in Waterford, PA. Fine cigars, vapes & friendly guidance. On-site cigar service for golf outings and private events." />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+  <link rel="manifest" href="site.webmanifest" />
+  <link rel="shortcut icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0f0f0f; --text:#f5f1e8; --muted:#b5b0a3; --accent:#c4a164; --golf:#1f513f;

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "High Street",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- use relative paths for favicon and manifest icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3337c18a88331b0c35ea3e9e6e26c