### PR TITLE
Restore hero image and relocate cigar carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,20 @@
       <div class="wrap">
         <h2>Our Cigars</h2>
         <p class="muted">Curated selection, properly stored, and priced fair. Ask for pairings & strength recommendations.</p>
+        <div class="cigar-slider" aria-label="Cigar selection photos">
+          <picture>
+            <source srcset="assets/img/cigarselection1.jpg" media="(min-width: 768px)" />
+            <img src="assets/img/cigarselection1light.jpg" alt="Humidor shelf with assorted cigars" loading="lazy" decoding="async" />
+          </picture>
+          <picture>
+            <source srcset="assets/img/cigarselection2.jpg" media="(min-width: 768px)" />
+            <img src="assets/img/cigarselection2light.jpg" alt="Close-up of cigar bundles" loading="lazy" decoding="async" />
+          </picture>
+          <picture>
+            <source srcset="assets/img/cigarselection3.jpg" media="(min-width: 768px)" />
+            <img src="assets/img/cigarselection3light.jpg" alt="Display of cigar boxes" loading="lazy" decoding="async" />
+          </picture>
+        </div>
         <div class="grid cols-3">
           <article class="card">
             <div class="thumb">Cigar Selection</div>
@@ -79,20 +93,6 @@
             <p>We stock popular hardware & juice—still keeping cigars center stage.</p>
             <span class="pill">One-stop shop</span>
           </article>
-        </div>
-        <div class="cigar-slider" aria-label="Cigar selection photos">
-          <picture>
-            <source srcset="assets/img/cigarselection1.jpg" media="(min-width: 768px)" />
-            <img src="assets/img/cigarselection1light.jpg" alt="Humidor shelf with assorted cigars" loading="lazy" decoding="async" />
-          </picture>
-          <picture>
-            <source srcset="assets/img/cigarselection2.jpg" media="(min-width: 768px)" />
-            <img src="assets/img/cigarselection2light.jpg" alt="Close-up of cigar bundles" loading="lazy" decoding="async" />
-          </picture>
-          <picture>
-            <source srcset="assets/img/cigarselection3.jpg" media="(min-width: 768px)" />
-            <img src="assets/img/cigarselection3light.jpg" alt="Display of cigar boxes" loading="lazy" decoding="async" />
-          </picture>
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -18,10 +18,10 @@ nav{display:flex;align-items:center;justify-content:space-between;padding:.8rem 
 .cigar-icon{width:22px;height:8px;border-radius:4px;background:linear-gradient(90deg,#5e3a1a,#a7723d 70%,#e6c89b 70%,#e6c89b 85%,#f5f1e8 85%);position:relative}
 .cigar-icon::after{content:"";position:absolute;right:0;top:0;bottom:0;width:6px;border-radius:0 4px 4px 0;background:radial-gradient(circle at right,#ff5722,#ffab49 60%,transparent 61%)}
 .hero{position:relative;min-height:72vh;display:grid;align-items:center}
-.hero::before{content:"";position:absolute;inset:0;background:linear-gradient(to bottom,rgba(0,0,0,.1),rgba(0,0,0,.75));z-index:0}
+.hero::before{content:"";position:absolute;inset:0;background:linear-gradient(to bottom,rgba(0,0,0,.1),rgba(0,0,0,.6));z-index:0}
 .hero .wrap{position:relative;z-index:1;padding:clamp(3rem,8vw,5rem) 1rem}
 .hero-img{position:absolute;inset:0;z-index:-1;overflow:hidden}
-.hero-img img{width:100%;height:100%;object-fit:cover;filter:grayscale(10%) contrast(105%)}
+.hero-img img{width:100%;height:100%;object-fit:cover}
 h1{font-size:clamp(2rem,5vw,3.2rem);line-height:1.15;margin:0 0 .75rem}
 .kicker{text-transform:uppercase;letter-spacing:.18em;color:var(--muted);font-size:.85rem}
 .lead{max-width:45ch;color:#e8e2d7;margin:.5rem 0 1.25rem}
@@ -54,7 +54,7 @@ footer{padding:2.5rem 0;color:#cfc9bb;border-top:1px solid #191919}
 }
 
 /* Cigar slider */
-.cigar-slider{position:relative;overflow:hidden;border-radius:var(--radius);aspect-ratio:16/10;margin-top:1.5rem}
+.cigar-slider{position:relative;overflow:hidden;border-radius:var(--radius);aspect-ratio:16/10;margin:1.5rem 0}
 .cigar-slider picture{position:absolute;inset:0;opacity:0;animation:fade 18s infinite}
 .cigar-slider picture:nth-child(1){animation-delay:0s}
 .cigar-slider picture:nth-child(2){animation-delay:6s}


### PR DESCRIPTION
## Summary
- Fix hero image overlay and color by removing grayscale filter
- Move cigar selection photos above product grid and keep automatic carousel rotation

## Testing
- `npx prettier --check index.html styles.css`
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b344ce640c833186f141e39df685db