### PR TITLE
Use JPEG hero images with stronger overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ nav{display:flex;align-items:center;justify-content:space-between;padding:.8rem 
 .cigar-icon{width:22px;height:8px;border-radius:4px;background:linear-gradient(90deg,#5e3a1a,#a7723d 70%,#e6c89b 70%,#e6c89b 85%,#f5f1e8 85%);position:relative}
 .cigar-icon::after{content:"";position:absolute;right:0;top:0;bottom:0;width:6px;border-radius:0 4px 4px 0;background:radial-gradient(circle at right,#ff5722,#ffab49 60%,transparent 61%)}
 .hero{position:relative;min-height:72vh;display:grid;align-items:center}
-.hero::before{content:"";position:absolute;inset:0;background:linear-gradient(to bottom,rgba(0,0,0,.1),rgba(0,0,0,.6));z-index:0}
+.hero::before{content:"";position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:0}
 .hero .wrap{position:relative;z-index:1;padding:clamp(3rem,8vw,5rem) 1rem}
 .hero-img{position:absolute;inset:0;z-index:-1;overflow:hidden}
 .hero-img img{width:100%;height:100%;object-fit:cover}


### PR DESCRIPTION
## Summary
- remove previously added hero PNG assets
- reference existing herofull.jpg and herolight.jpg in hero preload and picture
- retain darker hero overlay for legibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b347b555788331840634ea55f4060a