### PR TITLE
Fix hero display and add cigar photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="preload" as="image" href="assets/img/herolight.jpg"
         imagesrcset="assets/img/herofull.jpg 2661w, assets/img/herolight.jpg 1079w"
         imagesizes="100vw" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles.css?v=2" />
 </head>
 <body>
   <!-- Age/ID banner -->
@@ -39,12 +39,8 @@
   </header>
 
   <main id="top">
-    <section class="hero" aria-label="Hero">
-      <picture class="hero-img" aria-hidden="true">
-        <source srcset="assets/img/herofull.jpg" media="(min-width: 768px)" />
-        <img src="assets/img/herolight.jpg" alt=""
-             width="2661" height="1497" decoding="async" fetchpriority="high" />
-      </picture>
+    <section class="hero">
+      <div class="hero-img" aria-hidden="true"></div>
       <div class="wrap">
         <div class="kicker">Neighborhood Humidor • Owner-led • Friendly Guidance</div>
         <h1>Exceptional Cigars. Zero Snobbery.</h1>
@@ -76,19 +72,24 @@
         </div>
         <div class="grid cols-3">
           <article class="card">
-            <div class="thumb">Cigar Selection</div>
+            <img src="assets/img/cigarselection1light.jpg" width="1200" height="750" loading="lazy"
+                 alt="Humidor rows of cigars — selection 1">
             <h3>Curated Sticks</h3>
             <p>From mild to full—tell us what you like; we’ll match flavor, size, and burn time.</p>
             <span class="pill">Beginner-friendly</span>
           </article>
+
           <article class="card">
-            <div class="thumb">Accessories</div>
+            <img src="assets/img/cigarselection2light.jpg" width="1200" height="750" loading="lazy"
+                 alt="Humidor rows of cigars — selection 2">
             <h3>Accessories</h3>
             <p>Cutters, torch lighters, travel cases—grab-and-go or giftable add-ons.</p>
             <span class="pill">Gift-ready</span>
           </article>
+
           <article class="card">
-            <div class="thumb">Vape & Juice</div>
+            <img src="assets/img/cigarselection3light.jpg" width="1200" height="750" loading="lazy"
+                 alt="Humidor rows of cigars — selection 3">
             <h3>Vapes (Yes, but…)</h3>
             <p>We stock popular hardware & juice—still keeping cigars center stage.</p>
             <span class="pill">One-stop shop</span>

--- a/styles.css
+++ b/styles.css
@@ -18,10 +18,20 @@ nav{display:flex;align-items:center;justify-content:space-between;padding:.8rem 
 .cigar-icon{width:22px;height:8px;border-radius:4px;background:linear-gradient(90deg,#5e3a1a,#a7723d 70%,#e6c89b 70%,#e6c89b 85%,#f5f1e8 85%);position:relative}
 .cigar-icon::after{content:"";position:absolute;right:0;top:0;bottom:0;width:6px;border-radius:0 4px 4px 0;background:radial-gradient(circle at right,#ff5722,#ffab49 60%,transparent 61%)}
 .hero{position:relative;min-height:72vh;display:grid;align-items:center}
-.hero::before{content:"";position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:0}
-.hero .wrap{position:relative;z-index:1;padding:clamp(3rem,8vw,5rem) 1rem}
-.hero-img{position:absolute;inset:0;z-index:-1;overflow:hidden}
-.hero-img img{width:100%;height:100%;object-fit:cover}
+.hero-img{
+  position:absolute;inset:0;z-index:0;
+  background-image:url('assets/img/herolight.jpg'); /* NOTE: relative path (no leading slash) */
+  background-size:cover;background-position:center;
+  opacity:.35;filter:grayscale(10%) contrast(105%)
+}
+.hero .wrap{position:relative;z-index:1}
+.hero::before{
+  content:"";position:absolute;inset:0;z-index:0;
+  background:
+    radial-gradient(100% 60% at 0% 100%,rgba(196,161,100,.28),transparent 60%),
+    linear-gradient(to bottom, rgba(0,0,0,.4), rgba(0,0,0,.84))
+}
+@media (max-width:540px){.hero{min-height:68vh}}
 h1{font-size:clamp(2rem,5vw,3.2rem);line-height:1.15;margin:0 0 .75rem}
 .kicker{text-transform:uppercase;letter-spacing:.18em;color:var(--muted);font-size:.85rem}
 .lead{max-width:45ch;color:#e8e2d7;margin:.5rem 0 1.25rem}
@@ -32,6 +42,7 @@ h2{font-size:clamp(1.4rem,3.5vw,2rem);margin:0 0 .8rem}
 .grid{display:grid;gap:1rem}
 .grid.cols-3{grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
 .card{background:var(--card);border:1px solid #242424;border-radius:var(--radius);padding:1rem}
+.card img{display:block;width:100%;height:auto;border-radius:12px;border:1px solid #232323}
 .pill{display:inline-block;background:#143b2f;color:#d4ede4;border:1px solid #205842;border-radius:999px;padding:.25rem .6rem;font-size:.8rem}
 .badge{display:inline-flex;align-items:center;gap:.35rem;font-weight:700;color:#ffd166}
 .list{margin:0;padding-left:1rem;color:#ddd}


### PR DESCRIPTION
## Summary
- Display hero background image with gradient overlay
- Replace empty cigar cards with real photos and add card image styles

## Testing
- `npx prettier --check index.html styles.css` (warn: code style issues found)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b34d5a37a0833199a551aad3171d11