### PR TITLE
Remove cigar card images while keeping offerings text

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,24 +72,18 @@
         </div>
         <div class="grid cols-3">
           <article class="card">
-            <img src="assets/img/cigarselection1light.jpg" width="1200" height="750" loading="lazy"
-                 alt="Humidor rows of cigars — selection 1">
             <h3>Curated Sticks</h3>
             <p>From mild to full—tell us what you like; we’ll match flavor, size, and burn time.</p>
             <span class="pill">Beginner-friendly</span>
           </article>
 
           <article class="card">
-            <img src="assets/img/cigarselection2light.jpg" width="1200" height="750" loading="lazy"
-                 alt="Humidor rows of cigars — selection 2">
             <h3>Accessories</h3>
             <p>Cutters, torch lighters, travel cases—grab-and-go or giftable add-ons.</p>
             <span class="pill">Gift-ready</span>
           </article>
 
           <article class="card">
-            <img src="assets/img/cigarselection3light.jpg" width="1200" height="750" loading="lazy"
-                 alt="Humidor rows of cigars — selection 3">
             <h3>Vapes (Yes, but…)</h3>
             <p>We stock popular hardware & juice—still keeping cigars center stage.</p>
             <span class="pill">One-stop shop</span>


### PR DESCRIPTION
## Summary
- Reintroduce a grid of cards after the cigar slider that show curated sticks, accessories, and vape offerings without images.

## Testing
- `npx --yes prettier@3.3.2 --check index.html`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36aa9d92483318fc74d4c0b0a2c1c